### PR TITLE
Optimized graph generation to avoid costly compositions

### DIFF
--- a/sanskrit_parser/lexical_analyzer/__init__.py
+++ b/sanskrit_parser/lexical_analyzer/__init__.py
@@ -8,7 +8,7 @@ Use the ``SanskritLexicalAnalyzer`` to split a sentence (wrapped in a
 .. code:: python
 
     >>> from __future__ import print_function
-    >>> from sanskrit_parser.lexical_analyzer.SanskritLexicalAnalyzer import SanskritLexicalAnalyzer
+    >>> from sanskrit_parser.lexical_analyzer.sanskrit_lexical_analyzer import SanskritLexicalAnalyzer
     >>> from sanskrit_parser.base.sanskrit_base import SanskritObject, SLP1
     >>> sentence = SanskritObject("astyuttarasyAMdishidevatAtmA")
     >>> analyzer = SanskritLexicalAnalyzer()
@@ -54,7 +54,7 @@ Command line usage
 
 ::
 
-    $ python -m sanskrit_parser.lexical_analyzer.SanskritLexicalAnalyzer astyuttarasyAMdishidevatAtmA --split
+    $ python -m sanskrit_parser.lexical_analyzer.sanskrit_lexical_analyzer astyuttarasyAMdishidevatAtmA --split
     Splits:
     [u'asti', u'uttarasyAm', u'diSi', u'devat', u'AtmA']
     [u'asti', u'uttarasyAm', u'diSi', u'devata', u'AtmA']
@@ -67,7 +67,7 @@ Command line usage
     [u'asti', u'uttara', u'syAm', u'diSi', u'devata', u'AtmA']
     [u'asti', u'uttarasyAm', u'diSi', u'de', u'vatA', u'AtmA']
 
-    $ python -m sanskrit_parser.lexical_analyzer.SanskritLexicalAnalyzer hares
+    $ python -m sanskrit_parser.lexical_analyzer.sanskrit_lexical_analyzer hares
     Input String: hares
     Input String in SLP1: hares
     [('hf#1', set(['cj', 'snd', 'prim', 'para', 'md', 'sys', 'prs', 'v', 'np', 'sg', 'op'])), ('hari#1', set(['na', 'mas', 'sg', 'gen'])), ('hari#1', set(['na', 'mas', 'abl', 'sg'])), ('hari#1', set(['na', 'fem', 'sg', 'gen'])), ('hari#1', set(['na', 'fem', 'abl', 'sg'])), ('hari#2', set(['na', 'mas', 'sg', 'gen'])), ('hari#2', set(['na', 'mas', 'abl', 'sg'])), ('hari#2', set(['na', 'fem', 'sg', 'gen'])), ('hari#2', set(['na', 'fem', 'abl', 'sg']))]

--- a/sanskrit_parser/lexical_analyzer/sanskrit_lexical_analyzer.py
+++ b/sanskrit_parser/lexical_analyzer/sanskrit_lexical_analyzer.py
@@ -33,7 +33,7 @@ class SanskritLexicalGraph(object):
     start = "__start__"
     end = "__end__"
 
-    def __init__(self, elem=None, end=False):
+    def __init__(self):
         ''' DAG Class Init
 
         Params:
@@ -42,8 +42,6 @@ class SanskritLexicalGraph(object):
         '''
         self.roots = []
         self.G = nx.DiGraph()
-        if elem is not None:
-            self.addNode(elem, root=True, end=end)
 
     def __iter__(self):
         ''' Iterate over nodes '''
@@ -204,10 +202,12 @@ class SanskritLexicalAnalyzer(object):
             Returns:
               SanskritLexicalGraph : DAG all possible splits
         '''
-        # Transform to internal canonical form
         self.dynamic_scoreboard = {}
+        # Transform to internal canonical form
         s = o.canonical()
+        # Initialize an empty graph to hold the splits
         self.splits = SanskritLexicalGraph()
+        # _possible_splits updates graph in self.splits with nodes and returns roots
         roots = self._possible_splits(s)
         if tag and len(roots) > 0:
             self.tagLexicalGraph(self.splits)
@@ -273,7 +273,7 @@ class SanskritLexicalAnalyzer(object):
                     r_roots = self._possible_splits(s_c_right)
                     # if there are valid splits of the right side
                     if r_roots:
-                        # Make sure we got a graph back
+                        # Make sure we got a set of roots back
                         assert isinstance(r_roots, set)
                         # if there are valid splits of the right side
                         if s_c_left not in node_cache:

--- a/sanskrit_parser/morphological_analyzer/SanskritMorphologicalAnalyzer.py
+++ b/sanskrit_parser/morphological_analyzer/SanskritMorphologicalAnalyzer.py
@@ -329,11 +329,11 @@ if __name__ == "__main__":
         print("Input String in SLP1:", i.canonical())
         import datetime
         print("Start Split:", datetime.datetime.now())
-        graph = s.getSandhiSplits(i, tag=True, debug=args.debug)
+        graph = s.getSandhiSplits(i, tag=True)
         print("End DAG generation:", datetime.datetime.now())
         with SanskritBase.outputctx(args.strict_io):
             if graph:
-                splits = graph.findAllPaths(max_paths=args.max_paths, debug=args.debug)
+                splits = graph.findAllPaths(max_paths=args.max_paths)
                 print("End pathfinding:", datetime.datetime.now())
                 print("Splits:")
                 for sp in splits:

--- a/sanskrit_parser/morphological_analyzer/SanskritMorphologicalAnalyzer.py
+++ b/sanskrit_parser/morphological_analyzer/SanskritMorphologicalAnalyzer.py
@@ -7,7 +7,7 @@
 '''
 from __future__ import print_function
 import sanskrit_parser.base.sanskrit_base as SanskritBase
-import sanskrit_parser.lexical_analyzer.SanskritLexicalAnalyzer as SanskritLexicalAnalyzer
+import sanskrit_parser.lexical_analyzer.sanskrit_lexical_analyzer as SanskritLexicalAnalyzer
 from sanskrit_parser.util.DhatuWrapper import DhatuWrapper
 
 import constraint
@@ -16,31 +16,31 @@ import pprint
 import logging
 logger = logging.getLogger(__name__)
 
-need_lakara=False
+need_lakara = False
 
-dw=DhatuWrapper()
+dw = DhatuWrapper()
 
 def getSLP1Tagset(n):
-    return set(map(lambda x: x.canonical(),list(n[1])))
+    return set(map(lambda x: x.canonical(), list(n[1])))
 
 # Lakaras
-_lakaras=set(['law','liw','luw','lrw','low','laN','liN','luN','lfN','viDiliN','law-karmaRi','liw-karmaRi','luw-karmaRi','lrw-karmaRi','low-karmaRi','laN-karmaRi','liN-karmaRi','luN-karmaRi','lfN-karmaRi'])
+_lakaras = set(['law', 'liw', 'luw', 'lrw', 'low', 'laN', 'liN', 'luN', 'lfN', 'viDiliN', 'law-karmaRi', 'liw-karmaRi', 'luw-karmaRi', 'lrw-karmaRi', 'low-karmaRi', 'laN-karmaRi', 'liN-karmaRi', 'luN-karmaRi', 'lfN-karmaRi'])
 # Disallowed last padas
-_ldis = set(['samAsapUrvapadanAmapadam','upasargaH'])
+_ldis = set(['samAsapUrvapadanAmapadam', 'upasargaH'])
 # Vacanas
-_vacanas=set(['ekavacanam','dvivacanam','bahuvacanam'])
+_vacanas = set(['ekavacanam', 'dvivacanam', 'bahuvacanam'])
 # Puruzas
-_puruzas=['praTamapuruzaH','maDyamapuruzaH','uttamapuruzaH']
-prathama='praTamAviBaktiH'
+_puruzas = ['praTamapuruzaH', 'maDyamapuruzaH', 'uttamapuruzaH']
+prathama = 'praTamAviBaktiH'
 # Lingas
-_lingas=set(['puMlliNgam','napuMsakaliNgam','strIliNgam'])
-_sankhya=set(['saNKyA'])
+_lingas = set(['puMlliNgam', 'napuMsakaliNgam', 'strIliNgam'])
+_sankhya = set(['saNKyA'])
 # Samastapada former parts
-_samastas=set(['samAsapUrvapadanAmapadam'])
+_samastas = set(['samAsapUrvapadanAmapadam'])
 # tiGanta vibhaktis
-_vibhaktis=set(['praTamAviBaktiH','dvitIyAviBaktiH','tritIyAviBaktiH',
-                'caturTIviBaktiH','paNcamIviBaktiH','zazWIviBaktiH',
-                'saptamIviBaktiH','saMboDanaviBaktiH'])
+_vibhaktis = set(['praTamAviBaktiH', 'dvitIyAviBaktiH', 'tritIyAviBaktiH',
+                'caturTIviBaktiH', 'paNcamIviBaktiH', 'zazWIviBaktiH',
+                'saptamIviBaktiH', 'saMboDanaviBaktiH'])
 _dvitiya = 'dvitIyAviBaktiH'
 _sambodhana = 'saMboDanaviBaktiH'
 
@@ -50,7 +50,7 @@ _sambodhana = 'saMboDanaviBaktiH'
 def nonempty(*nodes):
     ''' No empty tagsets allowed '''
     for n in nodes:
-        if list(n[1])==[]:
+        if list(n[1]) == []:
             return False
     return True
 
@@ -59,34 +59,34 @@ def oneLakara(*nodes):
     ''' Only one Lakara is allowed '''
     # lakaras in SLP1
     global need_lakara
-    l=0
+    l = 0
     for n in nodes:
-        nset=getSLP1Tagset(n)
+        nset = getSLP1Tagset(n)
         if not(_lakaras.isdisjoint(nset)):
-            l=l+1
+            l = l + 1
     # Variable to enforce a lakara
     if need_lakara:
-        return l==1
+        return l == 1
     else:
-        return l<=1 
+        return l <= 1
 
 # Last pada cannot be an upasarga or samasapurvapada
 def lastWord(*nodes):
     n = nodes[-1]
-    nset=getSLP1Tagset(n)
+    nset = getSLP1Tagset(n)
     r = _ldis.isdisjoint(nset)
     logger.debug(nset)
     return r
 
 # Upasarga must be before a verb
 def upasarga(*nodes):
-    r = True 
-    for ix,n in enumerate(nodes):
-        nset=getSLP1Tagset(n)
+    r = True
+    for ix, n in enumerate(nodes):
+        nset = getSLP1Tagset(n)
         if set(['upasargaH']) <= nset:
-            r = r and (not _lakaras.isdisjoint(getSLP1Tagset(nodes[ix+1])))
+            r = r and (not _lakaras.isdisjoint(getSLP1Tagset(nodes[ix + 1])))
     return r
-    
+
 # Rules for prathamA/sambodhanA
 def prathamA(*nodes):
     ''' Rules for prathamA, sambodhanA vibhaktis 
@@ -95,127 +95,127 @@ def prathamA(*nodes):
         sambodhana vibhakti rules: Lakara must be in madhyamapurusha
 
     '''
-    r=True
-    vacana=None
-    puruza=None
+    r = True
+    vacana = None
+    puruza = None
     for n in nodes:
-        nset=getSLP1Tagset(n)
+        nset = getSLP1Tagset(n)
         # Pick the first lakara
         if not(_lakaras.isdisjoint(nset)):
-            vacana=nset.intersection(_vacanas)
+            vacana = nset.intersection(_vacanas)
             logger.debug("Found Lakara vacana:{}".format(vacana))
-            assert len(vacana)==1, "Only one vacana allowed: {}".format(list(vacana))
-            vacana=list(vacana)[0]
-            puruza=nset.intersection(_puruzas)
+            assert len(vacana) == 1, "Only one vacana allowed: {}".format(list(vacana))
+            vacana = list(vacana)[0]
+            puruza = nset.intersection(_puruzas)
             logger.debug("Found Lakara puruza:{}".format(puruza))
-            assert len(puruza)==1, "Only one puruza allowed: {}".format(list(puruza))
-            puruza=list(puruza)[0]
+            assert len(puruza) == 1, "Only one puruza allowed: {}".format(list(puruza))
+            puruza = list(puruza)[0]
     # No lakara found
     if vacana is None:
         return not need_lakara
-    pstem=None
-    dstem=None
-    dvacana=None
-    yuzmad=False
+    pstem = None
+    dstem = None
+    dvacana = None
+    yuzmad = False
     for n in nodes:
-        nset=getSLP1Tagset(n)
+        nset = getSLP1Tagset(n)
         if prathama in nset:
-            mvacana=nset.intersection(_vacanas)
-            logger.debug("Found PrathamA {} vacana:{}".format(n[0],mvacana))
-            assert len(mvacana)==1, "Only one mvacana allowed: {}".format(list(mvacana))
-            mvacana=list(mvacana)[0]
+            mvacana = nset.intersection(_vacanas)
+            logger.debug("Found PrathamA {} vacana:{}".format(n[0], mvacana))
+            assert len(mvacana) == 1, "Only one mvacana allowed: {}".format(list(mvacana))
+            mvacana = list(mvacana)[0]
             logger.debug('Pre Prathama result:'.format(r))
-            r = r and (mvacana==vacana)
-            if puruza==_puruzas[1]:
+            r = r and (mvacana == vacana)
+            if puruza == _puruzas[1]:
                 # Can't have asmad with madhyama
-                r = r and (n[0]!='asmad')
-            elif puruza==_puruzas[2]:
+                r = r and (n[0] != 'asmad')
+            elif puruza == _puruzas[2]:
                 # Can't have yuzmad with uttama
-                r = r and (n[0]!='yuzmad')
+                r = r and (n[0] != 'yuzmad')
             else:
                 # Can't have either with prathama
-                r = r and ((n[0]!='yuzmad') and  (n[0]!='asmad'))
-            pstem=n[0]
-            yuzmad=yuzmad or (pstem=='yuzmad')
+                r = r and ((n[0] != 'yuzmad') and  (n[0] != 'asmad'))
+            pstem = n[0]
+            yuzmad = yuzmad or (pstem == 'yuzmad')
             logger.debug('Temp Prathama result:'.format(r))
         if _sambodhana in nset:
             logger.debug('Pre Sambodhana result:'.format(r))
-            dvacana=nset.intersection(_vacanas)
-            logger.debug("Found Sambodhana {} vacana:{}".format(n[0],dvacana))
-            assert len(dvacana)==1, "Only one dvacana allowed: {}".format(list(dvacana))
-            dvacana=list(dvacana)[0]
+            dvacana = nset.intersection(_vacanas)
+            logger.debug("Found Sambodhana {} vacana:{}".format(n[0], dvacana))
+            assert len(dvacana) == 1, "Only one dvacana allowed: {}".format(list(dvacana))
+            dvacana = list(dvacana)[0]
             # Lakara must be in madhyamapurusha
-            if puruza is not None: 
-                r = r and (puruza==_puruzas[1])
+            if puruza is not None:
+                r = r and (puruza == _puruzas[1])
                 logger.debug('Temp Sambodhana result:'.format(r))
-            dstem=n[0]
+            dstem = n[0]
     if dvacana is not None:
         # All nodes has been seen, we have found a dvitiya
         if pstem is not None:
             # Must match Sambodhana vacana
-            logger.debug('Sambodhana check: {} {}  Yushmad {} mvacana {} dvacana {}'.format(pstem,dstem,yuzmad,mvacana,dvacana))
-            ## Prathama stem must be yuzmad
-            #r = r and yuzmad
+            logger.debug('Sambodhana check: {} {}  Yushmad {} mvacana {} dvacana {}'.format(pstem, dstem, yuzmad, mvacana, dvacana))
+            # # Prathama stem must be yuzmad
+            # r = r and yuzmad
             r = r and (mvacana == dvacana)
     logger.debug('Returning:'.format(r))
     return r
 
 
-   
+
 
 # all padas in same case must match in linga and vacana
 def vibhaktiAgreement(*nodes):
     ''' All padas in same vibhakti must agree in linga and vacana '''
-    maps={}
+    maps = {}
     for n in nodes:
-        nset=getSLP1Tagset(n)
-        vibhakti = _vibhaktis.intersection(nset) 
+        nset = getSLP1Tagset(n)
+        vibhakti = _vibhaktis.intersection(nset)
         if vibhakti:
-            assert len(vibhakti)==1, "Only one vibhakti allowed: {}".format(list(vibhakti))
+            assert len(vibhakti) == 1, "Only one vibhakti allowed: {}".format(list(vibhakti))
             logger.debug("Found vibhakti:{}".format(vibhakti))
-            vibhakti=list(vibhakti)[0]
-            vacana=nset.intersection(_vacanas)
+            vibhakti = list(vibhakti)[0]
+            vacana = nset.intersection(_vacanas)
             logger.debug("Found vacana:{}".format(vacana))
-            assert len(vacana)==1, "Only one vacana allowed: {}".format(list(vacana))
-            vacana=list(vacana)[0]
-            linga=nset.intersection(_lingas)
+            assert len(vacana) == 1, "Only one vacana allowed: {}".format(list(vacana))
+            vacana = list(vacana)[0]
+            linga = nset.intersection(_lingas)
             logger.debug("Found linga:{}".format(linga))
-            if len(linga)==0:
-                sankhya=nset.intersection(_sankhya)
-                if sankhya: # Is "Sankhya" type (kati etc.)
+            if len(linga) == 0:
+                sankhya = nset.intersection(_sankhya)
+                if sankhya:  # Is "Sankhya" type (kati etc.)
                     continue
-            assert len(linga)==1, "Only one linga allowed: {}".format(list(linga))
-            linga=list(linga)[0]
-            slv = set([linga,vacana])
+            assert len(linga) == 1, "Only one linga allowed: {}".format(list(linga))
+            linga = list(linga)[0]
+            slv = set([linga, vacana])
             if vibhakti in maps:
                 if maps[vibhakti] != slv:
-                    logger.debug("Unequal:{} {}".format(maps[vibhakti],slv))
+                    logger.debug("Unequal:{} {}".format(maps[vibhakti], slv))
                     return False
                 else:
-                    logger.debug("Equal:{} {}".format(maps[vibhakti],slv))
+                    logger.debug("Equal:{} {}".format(maps[vibhakti], slv))
             else:
-                maps[vibhakti]=slv
-                logger.debug("Map: {} : {}".format(vibhakti,slv))
+                maps[vibhakti] = slv
+                logger.debug("Map: {} : {}".format(vibhakti, slv))
     return True
 
 # Only sakarmaka dhatus are allowed karma
 def sakarmakarule(*nodes):
-    global dw # DhatuWrapper
+    global dw  # DhatuWrapper
     dvitiya = False
     sakarmaka = False
     for n in nodes:
-        nset=getSLP1Tagset(n)
+        nset = getSLP1Tagset(n)
         if _dvitiya in nset:
             # Found a dvitiya
-            dvitiya=True
-            logger.debug("Dvitiya: {} {}".format(n[0],list(nset)))
+            dvitiya = True
+            logger.debug("Dvitiya: {} {}".format(n[0], list(nset)))
         if not(_lakaras.isdisjoint(nset)):
             # Found a lakara, can get the dhatu
-            dh=n[0]
-            hpos=dh.find('#')
+            dh = n[0]
+            hpos = dh.find('#')
             if hpos != -1:
                 dh = dh[:hpos]
-            logger.debug("Lakara: {} {}".format(dh,list(nset)))
+            logger.debug("Lakara: {} {}".format(dh, list(nset)))
             sakarmaka = dw.is_sakarmaka(dh)
             logger.debug("Sakarmakatva: {}".format(sakarmaka))
     return sakarmaka or (not dvitiya)
@@ -225,15 +225,15 @@ def samasarules(*nodes):
     ''' samasa constituents must be followed by tiGantas 
         (or other samasa constituents)
     '''
-    r=True
-    l=len(nodes)-1
-    for ix,n in enumerate(nodes):
-        nset=getSLP1Tagset(n)
+    r = True
+    l = len(nodes) - 1
+    for ix, n in enumerate(nodes):
+        nset = getSLP1Tagset(n)
         if not _samastas.isdisjoint(nset):
-            if ix==l:
+            if ix == l:
                 return False
             else:
-                nset1=getSLP1Tagset(nodes[ix+1])
+                nset1 = getSLP1Tagset(nodes[ix + 1])
                 if _samastas.isdisjoint(nset1):
                     r = r and (not _vibhaktis.isdisjoint(nset1))
     return r
@@ -248,44 +248,44 @@ class SanskritMorphologicalAnalyzer(SanskritLexicalAnalyzer.SanskritLexicalAnaly
     
     """
     def __init__(self, lexical_lookup="inria"):
-        super(SanskritMorphologicalAnalyzer,self).__init__(lexical_lookup)
+        super(SanskritMorphologicalAnalyzer, self).__init__(lexical_lookup)
 
-    def constrainPath(self,path):
+    def constrainPath(self, path):
         ''' Apply Morphological Constraints on path
 
         Params:
             path(list): List of SanskritObjects (tagged)
         '''
-        _ncache={}
-        vlist=[]
+        _ncache = {}
+        vlist = []
         def _uniq(s):
             if s not in _ncache:
-                _ncache[s]=0
+                _ncache[s] = 0
                 return s
             else:
-                _ncache[s]=_ncache[s]+1
-                return s+"_"+str(_ncache[s])
+                _ncache[s] = _ncache[s] + 1
+                return s + "_" + str(_ncache[s])
         # Ensure we have tags
         for p in path:
             assert p.tags, "No tags for {}".format(p)
         # Solver
         problem = constraint.Problem()
         for p in path:
-            v=_uniq(str(p))
+            v = _uniq(str(p))
             vlist.append(v)
-            logger.debug("Added Variable {} {}".format(v,p.tags))
-            problem.addVariable(v,p.tags)
+            logger.debug("Added Variable {} {}".format(v, p.tags))
+            problem.addVariable(v, p.tags)
         problem.addConstraint(oneLakara)
-        problem.addConstraint(lastWord,vlist)
-        problem.addConstraint(upasarga,vlist)
-        problem.addConstraint(prathamA,vlist)
-        problem.addConstraint(samasarules,vlist)
-        problem.addConstraint(vibhaktiAgreement,vlist)
-        problem.addConstraint(sakarmakarule,vlist)
-        problem.addConstraint(nonempty,vlist)
-        s=problem.getSolutions()
+        problem.addConstraint(lastWord, vlist)
+        problem.addConstraint(upasarga, vlist)
+        problem.addConstraint(prathamA, vlist)
+        problem.addConstraint(samasarules, vlist)
+        problem.addConstraint(vibhaktiAgreement, vlist)
+        problem.addConstraint(sakarmakarule, vlist)
+        problem.addConstraint(nonempty, vlist)
+        s = problem.getSolutions()
         return s
-    
+
 if __name__ == "__main__":
     from argparse import ArgumentParser
     def getArgs():
@@ -296,13 +296,13 @@ if __name__ == "__main__":
         # Parser Setup
         parser = ArgumentParser(description='Lexical Analyzer')
         # String to encode
-        parser.add_argument('data',nargs="?",type=str,default="astyuttarasyAMdishidevatAtmA")
+        parser.add_argument('data', nargs="?", type=str, default="astyuttarasyAMdishidevatAtmA")
         # Input Encoding (autodetect by default)
-        parser.add_argument('--input-encoding',type=str,default=None)
+        parser.add_argument('--input-encoding', type=str, default=None)
         # Need a lakara
-        parser.add_argument('--need-lakara',action='store_true')
-        parser.add_argument('--debug',action='store_true')
-        parser.add_argument('--max-paths',type=int,default=10)
+        parser.add_argument('--need-lakara', action='store_true')
+        parser.add_argument('--debug', action='store_true')
+        parser.add_argument('--max-paths', type=int, default=10)
         parser.add_argument('--lexical-lookup', type=str, default="combined")
         parser.add_argument('--strict-io', action='store_true',
                             help="Do not modify the input/output string to match conventions", default=False)
@@ -310,45 +310,45 @@ if __name__ == "__main__":
 
     def main():
         global need_lakara
-        args=getArgs()
+        args = getArgs()
         print("Input String:", args.data)
         need_lakara = args.need_lakara
-        
+
         if args.debug:
             logging.basicConfig(filename='SanskritMorphologicalAnalyzer.log', filemode='w', level=logging.DEBUG)
         else:
             logging.basicConfig(filename='SanskritMorphologicalAnalyzer.log', filemode='w', level=logging.INFO)
-        s=SanskritMorphologicalAnalyzer(args.lexical_lookup)
+        s = SanskritMorphologicalAnalyzer(args.lexical_lookup)
         if args.input_encoding is None:
             ie = None
         else:
             ie = SanskritBase.SCHEMES[args.input_encoding]
-        i=SanskritBase.SanskritObject(args.data,encoding=ie,
+        i = SanskritBase.SanskritObject(args.data, encoding=ie,
                                       strict_io=args.strict_io,
                                       replace_ending_visarga=None)
-        print("Input String in SLP1:",i.canonical())
+        print("Input String in SLP1:", i.canonical())
         import datetime
         print("Start Split:", datetime.datetime.now())
-        graph=s.getSandhiSplits(i,tag=True,debug=args.debug)
+        graph = s.getSandhiSplits(i, tag=True, debug=args.debug)
         print("End DAG generation:", datetime.datetime.now())
         with SanskritBase.outputctx(args.strict_io):
             if graph:
-                splits=graph.findAllPaths(max_paths=args.max_paths,debug=args.debug)
+                splits = graph.findAllPaths(max_paths=args.max_paths, debug=args.debug)
                 print("End pathfinding:", datetime.datetime.now())
                 print("Splits:")
                 for sp in splits:
-                    print("Lexical Split:",sp)
-                    p=s.constrainPath(sp)
+                    print("Lexical Split:", sp)
+                    p = s.constrainPath(sp)
                     if p:
                         print("Valid Morphologies")
                         for pp in p:
-                            print([(spp,pp[str(spp)]) for spp in sp])
+                            print([(spp, pp[str(spp)]) for spp in sp])
                     else:
                         print("No valid morphologies for this split")
                 print("End Morphological Analysis:", datetime.datetime.now())
             else:
                 print("No Valid Splits Found")
                 return
-            
+
     main()
 

--- a/tests/generate_uohd_LexicalAnalyzer_pass_fail.py
+++ b/tests/generate_uohd_LexicalAnalyzer_pass_fail.py
@@ -8,9 +8,10 @@ import json
 import logging
 import os
 import re
+import progressbar
 
 from sanskrit_parser.base.sanskrit_base import SanskritObject, SLP1
-from sanskrit_parser.lexical_analyzer.SanskritLexicalAnalyzer import SanskritLexicalAnalyzer
+from sanskrit_parser.lexical_analyzer.sanskrit_lexical_analyzer import SanskritLexicalAnalyzer
 
 logger = logging.getLogger(__name__)
 
@@ -176,10 +177,11 @@ if __name__ == "__main__":
     skip = codecs.open(os.path.join(directory, "uohd_skip.txt"), "w", encoding='utf-8')
     error = codecs.open(os.path.join(directory, "uohd_error.txt"), "w", encoding='utf-8')
     lexan = SanskritLexicalAnalyzer()
-    maxrefs = 100
+    maxrefs = 5000
+    bar = progressbar.ProgressBar(max_value=maxrefs)
     fail_count = skip_count = error_count = pass_count = 0
     for full, split, ofull, osplit, filename, linenum in \
-            get_uohd_refs(lexan=lexan, maxrefs=maxrefs):
+            bar(get_uohd_refs(lexan=lexan, maxrefs=maxrefs)):
         test = json.dumps({"full": full,
                            "split": split,
                            "orig_full": ofull,

--- a/tests/test_SanskritLexicalAnalyer.py
+++ b/tests/test_SanskritLexicalAnalyer.py
@@ -74,7 +74,7 @@ def test_file_splits(lexan, splittext_refs):
     i = SanskritObject(f, encoding=SLP1)
     graph = lexan.getSandhiSplits(i)
     assert graph is not None
-    splits = graph.findAllPaths(max_paths=200, sort=False)
+    splits = graph.findAllPaths(max_paths=300, sort=False)
 #     if s not in [list(map(str, ss)) for ss in splits]:
 #         # Currently, this triggers a fallback to all_simple_paths
 #         splits = graph.findAllPaths(max_paths=10000, sort=False)

--- a/tests/test_SanskritLexicalAnalyer.py
+++ b/tests/test_SanskritLexicalAnalyer.py
@@ -6,7 +6,7 @@ import os
 import pytest
 import six
 import json
-from sanskrit_parser.lexical_analyzer.SanskritLexicalAnalyzer import SanskritLexicalAnalyzer
+from sanskrit_parser.lexical_analyzer.sanskrit_lexical_analyzer import SanskritLexicalAnalyzer
 from sanskrit_parser.base.sanskrit_base import SanskritObject, SLP1
 from tests.conftest import get_testcount
 

--- a/tests/test_SanskritLexicalAnalyer.py
+++ b/tests/test_SanskritLexicalAnalyer.py
@@ -74,7 +74,7 @@ def test_file_splits(lexan, splittext_refs):
     i = SanskritObject(f, encoding=SLP1)
     graph = lexan.getSandhiSplits(i)
     assert graph is not None
-    splits = graph.findAllPaths(max_paths=100, sort=False)
+    splits = graph.findAllPaths(max_paths=200, sort=False)
 #     if s not in [list(map(str, ss)) for ss in splits]:
 #         # Currently, this triggers a fallback to all_simple_paths
 #         splits = graph.findAllPaths(max_paths=10000, sort=False)


### PR DESCRIPTION
While running tests with the sanskrit_util branch which has a much larger vocabulary, I noticed that the graph generation process itself was taking a significant portion of the time for long input strings. Upon profiling, I tracked down that a lot of time was being spent in the SanskritLexicalGraph.appendtoNode method in the call to nx.compose. The networkx compose method essentially creates a fresh graph each time it is called, and copies the data over from the two graphs, which can create a lot of overhead. One way to optimize this is to just maintain one overall graph, since all subgraphs are added to it in the compose operation, and just keep track of the roots of the subgraphs corresponding to right splits (the rdag variable previously). The append operation then simply has to create edges from the given node to the roots of the rdag subgraph. I have implemented this change in this pull request in the SanskritLexicalAnalyzer class. 

Another small optimization was to add an lru_cache wrapper around the _is_valid_word method to cache query results for checking if words are valid. (For valid words, the lexical lookups already cache the results, but not for invalid words).

After these changes, the time taken to construct the graph goes down by between 5x-20x depending on the input. E.g.
**Before**
(sanskrit_util) $ python -m sanskrit_parser.lexical_analyzer.SanskritLexicalAnalyzer --input-encoding SLP1 --split "astyuttarasyAmdiSidevatAtmAhimAlayonAmanagADirAjaH"
Input String: astyuttarasyAmdiSidevatAtmAhimAlayonAmanagADirAjaH
Input String in SLP1: astyuttarasyAmdiSidevatAtmAhimAlayonAmanagADirAjaH
Start Split: 2018-03-08 22:56:01.815000
**Time for graph generation =  0:00:05.108000**
End DAG generation: 2018-03-08 22:56:06.923000
End pathfinding: 2018-03-08 22:56:06.931000

**After optimization**
(graph_opt) $ python -m sanskrit_parser.lexical_analyzer.sanskrit_lexical_analyzer --input-encoding SLP1 --split "astyuttarasyAmdiSidevatAtmAhimAlayonAmanagADirAjaH"
Input String: astyuttarasyAmdiSidevatAtmAhimAlayonAmanagADirAjaH
Input String in SLP1: astyuttarasyAmdiSidevatAtmAhimAlayonAmanagADirAjaH
Start Split: 2018-03-08 23:31:18.510000
**Time for graph generation =  0:00:00.455000**
End DAG generation: 2018-03-08 23:31:18.965000
End pathfinding: 2018-03-08 23:31:18.984000

(While a reduction from 5s to <0.5 may not seem like a lot in an absolute sense for a given sentence, when splitting thousands of sentences, such as in the CI tests, or for collecting accuracy metrics, this translates to a significant speedup)

Finally, this PR also includes changes to SanskritLexicalAnalyzer.py to make it flake8 clean, and rename to sanskrit_lexical_analyzer.py to match Python conventions. There are some WIP changes to SanskritMorphologicalAnalyzer to make it flake8 clean, but they can be ignored for the purposes of this PR/review.