### PR TITLE
Gensim optional and py 3.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "3.7"
   - "3.8"
+  - "3.9"
 install: pip install tox-travis
 script: tox
 notifications:

--- a/README.md
+++ b/README.md
@@ -13,14 +13,19 @@ Please feel free to ping us if you would like to collaborate on this project.
 
 ## Installation
 
-This project has been tested and developed using Python 3.7/3.8. We are aware of issues with Python 3.9 at present. 
-
+This project has been tested and developed using Python 3.7 - 3.9. To install the package:
 ```
 pip install sanskrit_parser
 ```
+To enable statistical scoring based on DCS, please also install gensim<4 and sentencepiece:
+```
+pip install gensim sentencepiece
+```
+See next section for some options if gensim installation fails, and you need the scoring feature.
 
 ### Gensim installation: Alternate options if `pip install` fails
-Note that `sanskrit_parser` depends on [`gensim`](https://radimrehurek.com/gensim/) for scoring, which requires the capability to [build C extensions for Python](https://docs.python.org/3/extending/building.html). If you have an appropriate C compiler for your system, `gensim` should be installed automatically during `pip install`. We have seen some cases where `pip install` is unable to install `gensim` on Windows, and the following instructions are for those situations.
+The scoring implementation in `sanskrit_parser` depends on [`gensim`](https://radimrehurek.com/gensim/) for scoring,
+which requires the capability to [build C extensions for Python](https://docs.python.org/3/extending/building.html). If you have an appropriate C compiler for your system, `gensim` should be installed automatically during `pip install`. We have seen some cases where `pip install` is unable to install `gensim` on Windows, and the following instructions are for those situations.
 
 On Windows, `gensim` typically requires the installation of Microsoft build tools for Visual studio 2019 as documented [here](https://wiki.python.org/moin/WindowsCompilers). If you cannot, or do not want to install MS build tools to compile extensions, some alternate options are:
 1. Install the pre-built Windows library from https://www.lfd.uci.edu/~gohlke/pythonlibs/. (Please follow the instructions on the website to install the dependencies first.)

--- a/sanskrit_parser/parser/sandhi.py
+++ b/sanskrit_parser/parser/sandhi.py
@@ -100,13 +100,12 @@ Command line usage
 """
 
 import itertools
-import os
 import pickle
 import logging
 import datetime
-import importlib.resources
 from zipfile import ZipFile
 from sanskrit_parser.base.sanskrit_base import SanskritNormalizedString, SCHEMES, outputctx
+from sanskrit_parser.util.data_manager import data_file_path
 
 
 class Sandhi(object):
@@ -129,11 +128,10 @@ class Sandhi(object):
 
     @staticmethod
     def _load_rules_pickle(filename):
-        with importlib.resources.path('sanskrit_parser', 'data') as base_dir:
-            zip_path = os.path.join(base_dir, 'sandhi_rules.zip')
-            with ZipFile(zip_path) as myzip:
-                with myzip.open(filename) as f:
-                    return pickle.load(f)
+        zip_path = data_file_path('sandhi_rules.zip')
+        with ZipFile(zip_path) as myzip:
+            with myzip.open(filename) as f:
+                return pickle.load(f)
 
     def _load_forward(self):
         if self.forward is None:

--- a/sanskrit_parser/util/DhatuWrapper.py
+++ b/sanskrit_parser/util/DhatuWrapper.py
@@ -3,14 +3,12 @@
 Wrapper around  kRShNamAchArya dhAtupATha to extract simple dhAtu attributes
 @author: Karthikeyan Madathil (@kmadathil)
 """
-from __future__ import print_function
 
 import logging
-import os
-import importlib.resources
 from tinydb import TinyDB, Query
 
 from sanskrit_parser.base.sanskrit_base import SanskritImmutableString, SCHEMES
+from sanskrit_parser.util.data_manager import data_file_path
 
 
 class DhatuWrapper(object):
@@ -23,9 +21,8 @@ class DhatuWrapper(object):
 
     def __init__(self, logger=None):
         self.logger = logger or logging.getLogger(__name__)
-        with importlib.resources.path('sanskrit_parser', 'data') as data_dir:
-            self.db = TinyDB(os.path.join(data_dir, self.db_file),
-                             access_mode='r')
+        db_path = data_file_path(self.db_file)
+        self.db = TinyDB(db_path, access_mode='r')
         assert len(self.db.all()) != 0
 
     def _get_dhatus(self, d):

--- a/sanskrit_parser/util/data_manager.py
+++ b/sanskrit_parser/util/data_manager.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""
+Utils to manage the data files included in the package
+
+"""
+
+import importlib_resources
+import atexit
+from contextlib import ExitStack
+
+
+def data_file_path(filename):
+    file_manager = ExitStack()
+    atexit.register(file_manager.close)
+    ref = importlib_resources.files('sanskrit_parser') / 'data' / filename
+    path = file_manager.enter_context(
+        importlib_resources.as_file(ref))
+    return str(path)

--- a/sanskrit_parser/util/inriaxmlwrapper.py
+++ b/sanskrit_parser/util/inriaxmlwrapper.py
@@ -48,23 +48,15 @@ Command line usage
 
 """
 
-from __future__ import print_function
-import os
+import pickle
+import sqlite3
 import logging
-import importlib.resources
 from collections import namedtuple
 
 from sanskrit_parser.base.sanskrit_base import SanskritImmutableString, SCHEMES
 from sanskrit_parser.util.lexical_lookup import LexicalLookup
 from sanskrit_parser.util.inriatagmapper import inriaTagMapper
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
-
-import sqlite3
-
+from sanskrit_parser.util.data_manager import data_file_path
 
 _db = namedtuple('_db', ['db_file', 'tags', 'stems', 'buf'])
 
@@ -101,9 +93,8 @@ class InriaXMLWrapper(LexicalLookup):
     def __init__(self, logger=None):
         self.pickle_file = "inria_forms.pickle"
         self.logger = logger or logging.getLogger(__name__)
-        with importlib.resources.path('sanskrit_parser', 'data') as base_dir:
-            db_file = os.path.join(base_dir, "inria_forms_pos.db")
-            pkl_path = os.path.join(base_dir, "inria_stems_tags_buf.pkl")
+        db_file = data_file_path("inria_forms_pos.db")
+        pkl_path = data_file_path("inria_stems_tags_buf.pkl")
         self.db = self._load_db(db_file, pkl_path)
 
     @staticmethod

--- a/sanskrit_parser/util/lexical_scorer.py
+++ b/sanskrit_parser/util/lexical_scorer.py
@@ -9,14 +9,21 @@ Requires sentencepiece to be installed
 @author: avinashvarna
 '''
 
-from __future__ import print_function, unicode_literals
-import os
 import sys
-import six
-import gensim
 import logging
-import sentencepiece as spm
-import importlib.resources
+
+from sanskrit_parser.util.data_manager import data_file_path
+
+try:
+    import sentencepiece as spm
+    import gensim
+    gensim_enabled = True
+except ImportError:
+    msg = 'gensim and/or sentencepiece not found. '
+    msg += 'Lexical scoring will be disabled\n'
+    msg += 'To enable scoring please install gensim and sentencepiece'
+    logging.warning(msg)
+    gensim_enabled = False
 
 
 class Scorer(object):
@@ -26,23 +33,28 @@ class Scorer(object):
 
     def __init__(self):
         self.logger = logging.getLogger(__name__)
-        with importlib.resources.path('sanskrit_parser', 'data') as data_dir:
-            self.sentencepiece_file = os.path.join(data_dir, self.sentencepiece_file)
-            self.word2vec_file = os.path.join(data_dir, self.word2vec_file)
-        self.sp = spm.SentencePieceProcessor()
-        self.sp.Load(self.sentencepiece_file)
-        self.model = gensim.models.Word2Vec.load(self.word2vec_file)
+        if gensim_enabled:
+            self.sentencepiece_file = data_file_path(self.sentencepiece_file)
+            self.sp = spm.SentencePieceProcessor()
+            self.sp.Load(self.sentencepiece_file)
+            self.word2vec_file = data_file_path(self.word2vec_file)
+            self.model = gensim.models.Word2Vec.load(self.word2vec_file)
 
     def score_splits(self, splits):
-        sentences = [" ".join(map(six.text_type, split)) for split in splits]
+        sentences = [" ".join(map(str, split)) for split in splits]
         return self.score_strings(sentences)
 
     def score_strings(self, sentences):
-        self.logger.debug("Sentence = %s", sentences)
-        pieces = [self.sp.EncodeAsPieces(sentence) for sentence in sentences]
-        self.logger.debug("Pieces = %s", pieces)
-        scores = self.model.score(pieces, total_sentences=len(sentences))
-        self.logger.debug("Score = %s", scores)
+        if gensim_enabled:
+            self.logger.debug("Sentence = %s", sentences)
+            pieces = [self.sp.EncodeAsPieces(sentence) for sentence in sentences]
+            self.logger.debug("Pieces = %s", pieces)
+            scores = self.model.score(pieces, total_sentences=len(sentences))
+            self.logger.debug("Score = %s", scores)
+        else:
+            # Use negative of length.
+            # This will result in longer sentences getting a higher weight
+            scores = [-len(sentence.split(' ')) for sentence in sentences]
         return scores
 
 
@@ -50,7 +62,7 @@ if __name__ == "__main__":
     from argparse import ArgumentParser
     parser = ArgumentParser(description='Lexical Scorer')
     parser.add_argument('--debug', action='store_true')
-    parser.add_argument('data', nargs="?", type=six.text_type, default=None)
+    parser.add_argument('data', nargs="?", type=str, default=None)
 
     args = parser.parse_args()
     if args.debug:

--- a/sanskrit_parser/util/sanskrit_data_wrapper.py
+++ b/sanskrit_parser/util/sanskrit_data_wrapper.py
@@ -7,13 +7,12 @@ Wrapper around data from Sanskrit data project
 
 from __future__ import print_function
 import logging
-import os
-import importlib.resources
 import sanskrit_util.analyze
 import sanskrit_util.context
 from sanskrit_util.schema import Nominal, Indeclinable, Verb, Gerund, Infinitive, ParticipleStem
 from sanskrit_parser.util.lexical_lookup import LexicalLookup
 from sanskrit_parser.base.sanskrit_base import SanskritImmutableString, DEVANAGARI, SLP1
+from sanskrit_parser.util.data_manager import data_file_path
 
 
 class SanskritDataWrapper(LexicalLookup):
@@ -21,8 +20,7 @@ class SanskritDataWrapper(LexicalLookup):
     db_file = 'sanskrit_data.db'
 
     def __init__(self, logger=None):
-        with importlib.resources.path('sanskrit_parser', 'data') as data_dir:
-            self.db_file = os.path.join(data_dir, self.db_file)
+        self.db_file = data_file_path(self.db_file)
         config = {
             "DATABASE_URI": 'sqlite:///' + self.db_file,
             "DATA_PATH": ""}

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
   install_requires=['indic_transliteration!=1.9.5,!=1.9.6', 'lxml', 'networkx', 'tinydb',
                     'six', 'flask', 'flask_restx', 'flask_cors',
                     'jsonpickle', 'sanskrit_util', 'sqlalchemy<1.4',
-                    'sentencepiece', 'gensim<4', 'pydot', 'pandas', 'xlrd'],
+                    'pydot', 'pandas', 'xlrd', 'importlib_resources'],
 
   # List additional groups of dependencies here (e.g. development
   # dependencies). You can install these using the following syntax,

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,18 @@
 [tox]
-envlist = lint, py37, py38
+envlist = lint, py37, py38, py39
 
 [travis]
 python =
   3.7: lint, py37, rest-api
   3.8: py38
+  3.9: py39
 
 [testenv]
 deps =
     pytest
     google_compute_engine
+	gensim<4
+	sentencepiece
 commands =
     pytest --test-count 1000 tests/test_DhatuWrapper.py tests/test_sandhi.py tests/test_SanskritLexicalAnalyzer.py tests/test_SandhiKosh.py tests/test_parser.py
 


### PR DESCRIPTION
* Fix #171 on py 3.9
* Make gensim installation optional. If gensim is not installed, a warning message is displayed and the lexical scoring will return a score proportional to the length of the split, so that shorter splits are weighted higher. 