### PR TITLE
Potential fix for issue #179

### DIFF
--- a/docs/ui/sanskrit_parser.js
+++ b/docs/ui/sanskrit_parser.js
@@ -15,8 +15,14 @@ function reject_split(id) {
     $("#card"+id).addClass("d-none")
 }
 
+function end_s_visarga(s) {
+    sr = s.replace(/स्$/,"ः").replace(/र्$/,"ः(र्)")
+    return sr
+}
+
 function parse_split(id) {
-    split = $("#header"+id).text()
+    //split = $("#header"+id).text()
+    split = $("#header"+id).attr("rawtext")
     url = urlbase + "sanskrit_parser/v1/parse-presegmented/" + split
     var btn = $(this);
     var btxt = btn.text();
@@ -63,13 +69,13 @@ function parse_split(id) {
     })
  }
 
-function createSplitPanel(heading, urlbase, id) {
+function createSplitPanel(heading, urlbase, id, rawtext) {
     "use strict;"
     // var cardClass = id % 2 ? "bg-secondary" : "bg-primary";
     var cardClass =  "border-dark mb-3";
     var expanded = id === 0 ? "show" : "";
     var h = "<div  id=\"card" + id + "\" class=\"text-dark\" class=\"card " + cardClass + " \"><div class=\"card-header text-dark\">";
-    h += "<a class=\"text-dark\" id=\"header" + id + "\" data-toggle=\"collapse\" href=\"#collapse" + id + "\" aria-expanded=\"false\" aria-controls=\"collapse" + id + "\">";
+    h += "<a class=\"text-dark\" id=\"header" + id + "\" data-toggle=\"collapse\" href=\"#collapse" + id + "\" aria-expanded=\"false\" aria-controls=\"collapse" + id + "\" rawtext=\"" + rawtext + "\">";
     h += heading + "</a>";
     h += "<button type=\"button\" id=\"reject" + id + "\" class=\"btn btn-primary alignright\" onclick=\"reject_split(" + id + ")\" >Reject</button>"
     h += "<button type=\"button\" id=\"analyze" + id + "\" class=\"btn btn-primary alignright\" onclick=\"parse_split(" + id + ")\" >Sabdabodha</button>"
@@ -81,39 +87,39 @@ function createSplitPanel(heading, urlbase, id) {
     return h;
 }
 
-function createPanel(heading, row, dot, urlbase, id) {
-    "use strict;"
-    var cardClass = id % 2 ? "bg-secondary" : "bg-primary";
-    var expanded = id === 0 ? "show" : "";
-    var h = "<div class=\"card " + cardClass + " \"><div class=\"card-header " + cardClass + "\">";
-    h += "<a class=\"text-white\" data-toggle=\"collapse\" href=\"#collapse" + id + "\" aria-expanded=\"false\" aria-controls=\"collapse" + id + "\">";
-    h += heading + "</a>";
-/*    h += heading + "</a><p class=\"alignright\"> <a target=\"_blank\" class=\"text-white\" href=\""; */
-/*    h += urlbase + "static/" + imgbase + ".dot.png\">(View Graph)</a></p><div style=\"clear: both;\"></div></div>"; */
-/*    h += urlbase + "sanskrit_parser/v1/graph/" + imgbase + "\">(View Graph)</a></p><div style=\"clear: both;\"></div></div>"; */
-/*    h += encodeURI("https://image-charts.com/chart?cht=gv:dot&chl=" + dot["split"]) + "\">(View Graph)</a></p><div style=\"clear: both;\"></div></div>"; */
-    h += "<button type=\"button\" class=\"btn btn-primary alignright\" data-toggle=\"modal\" data-target=\"#graphModal\" data-graph=\"" +  escapeAll(dot["split"]) + "\" data-title=\"Sandhi Graph\">View Graph</button><div style=\"clear: both;\"></div></div>";
-    h += "<div id=\"collapse" + id + "\" class=\"collapse " + expanded + "\"><div class=\"card-block\">";
-    h += "<ol class=\"list-group\">";
-    row.forEach(function (sitem, index) {
-        h += "<li class=\"list-group-item\"><table class=\"table table-striped\">";
-//	h += "<p class=\"alignright\"> <a target=\"_blank\" href=\"";
-//	h += urlbase + "static/" + imgbase + "_parse" + index + ".dot.png\">(View Parse Graph)</a></p><div style=\"clear: both;\"></div>"
-//	h += encodeURI("https://image-charts.com/chart?cht=gv:dot&chl=" + dot[index]) + "\">(View Parse Graph)</a></p><div style=\"clear: both;\"></div>"
-	h += "<button type=\"button\" class=\"btn btn-light alignright\" data-toggle=\"modal\" data-target=\"#graphModal\"\ data-graph=\"" +escapeAll(dot[index]) +  "\" data-title=\"Parse Graph\">View Parse Graph</button><div style=\"clear: both;\"></div></div>";
-        h += "<thead><th scope=\"col\">Word</th><th scope=\"col\">Possible Interpretations</th><th scope=\"col\">Role</th><th scope=\"col\">Linked To</th></thead><tbody>";
-        sitem.forEach(function (item) {
-            h += "<tr><th scope=\"row\">" + item[0] + "</th><td>";
-            h += item[1][0] + " - " + item[1][1] + "</td><td>";
-            h += item[2] + "</td><td>";
-            h += item[3] + "</td></tr>";
-        });
-        h += "</tbody></table></li>";
-    });
-    h += "</ol>";
-    h += "</div></div></div>";
-    return h;
-}
+// function createPanel(heading, row, dot, urlbase, id) {
+//     "use strict;"
+//     var cardClass = id % 2 ? "bg-secondary" : "bg-primary";
+//     var expanded = id === 0 ? "show" : "";
+//     var h = "<div class=\"card " + cardClass + " \"><div class=\"card-header " + cardClass + "\">";
+//     h += "<a class=\"text-white\" data-toggle=\"collapse\" href=\"#collapse" + id + "\" aria-expanded=\"false\" aria-controls=\"collapse" + id + "\">";
+//     h += heading + "</a>";
+// /*    h += heading + "</a><p class=\"alignright\"> <a target=\"_blank\" class=\"text-white\" href=\""; */
+// /*    h += urlbase + "static/" + imgbase + ".dot.png\">(View Graph)</a></p><div style=\"clear: both;\"></div></div>"; */
+// /*    h += urlbase + "sanskrit_parser/v1/graph/" + imgbase + "\">(View Graph)</a></p><div style=\"clear: both;\"></div></div>"; */
+// /*    h += encodeURI("https://image-charts.com/chart?cht=gv:dot&chl=" + dot["split"]) + "\">(View Graph)</a></p><div style=\"clear: both;\"></div></div>"; */
+//     h += "<button type=\"button\" class=\"btn btn-primary alignright\" data-toggle=\"modal\" data-target=\"#graphModal\" data-graph=\"" +  escapeAll(dot["split"]) + "\" data-title=\"Sandhi Graph\">View Graph</button><div style=\"clear: both;\"></div></div>";
+//     h += "<div id=\"collapse" + id + "\" class=\"collapse " + expanded + "\"><div class=\"card-block\">";
+//     h += "<ol class=\"list-group\">";
+//     row.forEach(function (sitem, index) {
+//         h += "<li class=\"list-group-item\"><table class=\"table table-striped\">";
+// //	h += "<p class=\"alignright\"> <a target=\"_blank\" href=\"";
+// //	h += urlbase + "static/" + imgbase + "_parse" + index + ".dot.png\">(View Parse Graph)</a></p><div style=\"clear: both;\"></div>"
+// //	h += encodeURI("https://image-charts.com/chart?cht=gv:dot&chl=" + dot[index]) + "\">(View Parse Graph)</a></p><div style=\"clear: both;\"></div>"
+// 	h += "<button type=\"button\" class=\"btn btn-light alignright\" data-toggle=\"modal\" data-target=\"#graphModal\"\ data-graph=\"" +escapeAll(dot[index]) +  "\" data-title=\"Parse Graph\">View Parse Graph</button><div style=\"clear: both;\"></div></div>";
+//         h += "<thead><th scope=\"col\">Word</th><th scope=\"col\">Possible Interpretations</th><th scope=\"col\">Role</th><th scope=\"col\">Linked To</th></thead><tbody>";
+//         sitem.forEach(function (item) {
+//             h += "<tr><th scope=\"row\">" + item[0] + "</th><td>";
+//             h += item[1][0] + " - " + item[1][1] + "</td><td>";
+//             h += item[2] + "</td><td>";
+//             h += item[3] + "</td></tr>";
+//         });
+//         h += "</tbody></table></li>";
+//     });
+//     h += "</ol>";
+//     h += "</div></div></div>";
+//     return h;
+// }
 
 // write small plugin for keypress enter detection
 $.fn.enterKey = function (fnc) {
@@ -226,8 +232,9 @@ $(document).ready( function () {
 		    return a.length > b.length;
                 });
 		splits.forEach(function (res) {
-		    var item = res.join(" ");
-		    restable += createSplitPanel(item, urlbase, panelID);
+		    var rawtext = res.join(" ")
+		    var item = res.map(end_s_visarga).join(" ");
+		    restable += createSplitPanel(item, urlbase, panelID, rawtext);
 		    panelID += 1;
                 });
 		$("#restable").append(restable);

--- a/sanskrit_parser/rest_api/api_v1.py
+++ b/sanskrit_parser/rest_api/api_v1.py
@@ -82,7 +82,10 @@ class Splits(Resource):
         g = analyzer.getSandhiSplits(vobj)
         if g:
             splits = g.find_all_paths(10)
-            jsplits = [[ss.devanagari(strict_io=False) for ss in s] for s in splits]
+            # We don't get output with visargas here.
+            # Why? Because this will need to be parsed later, and we need to distinguish s/r
+            # We rely on the UI to handle display correctly
+            jsplits = [[ss.devanagari(strict_io=True) for ss in s] for s in splits]
         else:
             jsplits = []
         r = {"input": v, "devanagari": vobj.devanagari(), "splits": jsplits}
@@ -97,11 +100,14 @@ class Parse_Presegmented(Resource):
         if request.args.get("strict") == "false":
             strict_p = False
         vobj = SanskritObject(v, strict_io=strict_p, replace_ending_visarga=None)
+        # We set strict_io to False so we get output with visargas
+        # If further processing is desired, this needs to be set to True
+        # And the UI must handle display
         parser = Parser(input_encoding=sanscript.SLP1,
-                        output_encoding="Devanagari",
+                        output_encoding=sanscript.DEVANAGARI,
+                        strict_io=False,   
                         replace_ending_visarga='s')
         mres = []
-        print(v)
         for split in parser.split(vobj.canonical(), limit=10, pre_segmented=True):
             parses = list(split.parse(limit=10))
             sdot = split.to_dot()
@@ -119,7 +125,7 @@ class Presegmented(Resource):
         """ Presegmented Split """
         vobj = SanskritObject(v, strict_io=True, replace_ending_visarga=None)
         parser = Parser(input_encoding=sanscript.SLP1,
-                        output_encoding="Devanagari",
+                        output_encoding=sanscript.DEVANAGARI,
                         replace_ending_visarga='s')
         splits = parser.split(vobj.canonical(), limit=10, pre_segmented=True)
         r = {"input": v, "devanagari": vobj.devanagari(), "splits": [x.serializable()['split'] for x in splits]}


### PR DESCRIPTION
Switch `split` REST API to output strict mode. This allows us to distinguish s- and r- antas. 
To make display friendlier, JS code now handles prettifying display of splits as visargantas, with the actual form stored in the "rawtext" attribute of the element. This attribute is used instead of text itself when sAbdabodha is requested.  