### PR TITLE
Scoring improvements

### DIFF
--- a/metrics/Scoring_evaluation.md
+++ b/metrics/Scoring_evaluation.md
@@ -1,0 +1,171 @@
+# Scoring Evaluation — Sandhi Split Ranking
+
+Two evaluation harnesses measure how well different scoring approaches
+rank sandhi split candidates from the DAG.
+
+---
+
+## Test A: Shared 200-Path Pool (Reranking Only)
+
+**File:** `scoring_eval_shared_pool.py`
+
+**Setup:** Find 200 paths from the graph using unit-weight (unweighted)
+search with beam K=200.  All five approaches re-rank the identical pool.
+This measures scoring power in isolation — how well each approach
+identifies the correct split when given a large, diverse pool of
+candidates — but does NOT measure how each approach performs when it
+drives its own search.
+
+**Results (all 9042 sandhi kosha entries):**
+
+```
+==============================================================================
+Approach              Recall@1  Recall@5 Recall@10 Recall@50    F1@1   F1@10  AvgPos  Found
+------------------------------------------------------------------------------
+min_words                57.8%     92.8%     97.0%     99.6%   73.7%   99.5%    1.6  100.0%
+cbow_raw                 67.2%     91.6%     97.4%    100.0%   85.2%   99.6%    1.3  100.0%
+cbow_norm                32.8%     54.8%     64.6%     84.4%   61.4%   89.0%   23.1  100.0%
+wordvec                   7.2%     18.2%     27.0%     52.2%   37.0%   64.7%   71.8  100.0%
+wc_primary               73.4%     98.0%     99.4%    100.0%   81.8%  100.0%    0.5  100.0%
+==============================================================================
+```
+
+**Key observations:**
+- All approaches have 100% Found — the unweighted K=200 beam captures
+  the correct split for every entry.
+- `wc_primary` (word-count-first + CBOW tiebreaker) wins on Recall@1
+  (73.4%) and Recall@5 (98.0%).
+- `cbow_raw` does well on Recall@1 (67.2%) but the tiebreaker in
+  `wc_primary` adds 6 points.
+- `cbow_norm` performs poorly — normalizing by piece count destroys the
+  signal.
+- `wordvec` is not useful as a standalone scorer (7.2% Recall@1).
+- This evaluation **overestimates** performance because it gives every
+  approach a large, pre-computed pool that is not representative of what
+  each approach would find under its own search.
+
+---
+
+## Test B: Per-Approach DAG Search (Honest)
+
+**File:** `scoring_eval.py`
+
+**Setup:** Each approach drives its own DAG search with beam K=10
+(corresponding to production `max_paths`).  Weighted approaches
+(`cbow_raw`, `cbow_norm`) set per-edge weights matching `score_graph()`
+(bigrams for internal edges) and run weighted shortest-path search.
+Unweighted approaches use unit-weight search.  `wc_primary` re-ranks
+the unweighted search pool with word-count-first + CBOW tiebreaker.
+`wordvec` is evaluated only as a re-ranker on the unweighted pool (it
+cannot be expressed as independent per-edge weights).
+
+**Results (all 9042 sandhi kosha entries):**
+
+```
+==============================================================================
+Approach              Recall@1  Recall@5 Recall@10    F1@1   F1@10  AvgPos  Found
+------------------------------------------------------------------------------
+min_words                66.0%     94.1%     97.5%   81.3%   99.4%    0.7   97.5%
+cbow_raw                 77.9%     95.4%     97.8%   88.3%   99.4%    0.5   97.8%
+cbow_norm                57.0%     89.7%     95.3%   74.8%   98.9%    1.0   95.3%
+wordvec                  12.5%     44.3%     97.5%   46.8%   99.4%    4.8   97.5%
+wc_primary               83.7%     97.2%     97.5%   89.5%   99.4%    0.2   97.5%
+==============================================================================
+```
+
+**Key observations:**
+- Found drops to ~97.5% for unweighted approaches — 2.5% of correct
+  splits have more words than the 10 shortest paths found (a fundamental
+  limitation of word-count-first search at K=10).
+- `wc_primary` wins on Recall@1 (83.7%) — the CBOW tiebreaker
+  effectively selects the best among shortest paths.
+- `cbow_raw` with bigram edge weights scores 77.9% Recall@1 and
+  achieves the highest Found (97.8%), capturing 0.3% more entries than
+  unweighted search.  However, its weighted beam sometimes drops the
+  correct split (91.3% Found before the bigram fix → 97.8% after).
+- `wc_primary` and `cbow_raw` are complementary: `wc_primary` is better
+  at ranking the correct split #1 when it's in the shortest-path pool;
+  `cbow_raw` finds correct splits slightly more often (97.8% vs 97.5%)
+  but ranks them lower.
+- `min_words` (no CBOW tiebreaker) drops 17.7 points from `wc_primary`,
+  confirming the tiebreaker is essential.
+- `cbow_norm` trails `cbow_raw` across the board.
+- `wordvec` remains unusable as a standalone scorer (12.5% Recall@1).
+
+---
+
+## Test C: Per-Approach DAG Search, K=50
+
+**Setup:** Same as Test B, but with beam K=50 (`--max-paths 50`).
+This is a production-tunable knob — wider beam captures more candidates
+at the cost of slower search.
+
+**Results (all 9042 sandhi kosha entries):**
+
+```
+==============================================================================
+Approach              Recall@1  Recall@5 Recall@10    F1@1   F1@10  AvgPos  Found
+------------------------------------------------------------------------------
+min_words                65.8%     94.1%     97.4%   81.2%   99.7%    1.1   99.7%
+cbow_raw                 77.9%     95.4%     97.8%   88.3%   99.4%    0.7   99.5%
+cbow_norm                57.0%     89.7%     95.3%   74.8%   98.9%    1.7   99.4%
+wordvec                   8.3%     24.9%     37.0%   39.5%   74.3%   21.4   99.7%
+wc_primary               84.3%     98.8%     99.5%   89.7%   99.9%    0.3   99.7%
+==============================================================================
+```
+
+**Key observations:**
+- Found rises to 99.7% (was 97.5% at K=10) — only ~25 of 9042 entries
+  miss the correct split entirely.
+- `wc_primary` R@1 improves from 83.7% → 84.3% with the wider beam.
+- `cbow_raw` R@1 stays flat at 77.9% — its weighted beam converges
+  faster and doesn't benefit from the wider K.
+- The 0.3% missed entries likely have the correct split at position
+  51+ (more words than the 50 shortest splits).
+
+### Test C.1: Per-Approach DAG Search, K=20
+```
+==============================================================================
+Approach              Recall@1  Recall@5 Recall@10    F1@1   F1@10  AvgPos  Found
+------------------------------------------------------------------------------
+min_words                65.4%     93.8%     97.3%   80.5%   99.5%    0.9   98.9%
+cbow_raw                 77.9%     95.4%     97.8%   88.3%   99.4%    0.6   99.0%
+cbow_norm                57.0%     89.7%     95.3%   74.8%   98.9%    1.3   98.1%
+wordvec                   9.6%     30.1%     48.6%   42.6%   83.4%    9.6   98.9%
+wc_primary               84.1%     98.5%     98.9%   89.7%   99.7%    0.2   98.9%
+==============================================================================
+```
+---
+
+## Comparison: All Tests
+
+| Metric | Test A (shared K=200) | Test B (K=10) | Test C (K=50) |
+|---|---|---|---|
+| Search | Unweighted shared pool | Per-approach | Per-approach |
+| Found | 100% | 97.5% | 99.7% |
+| wc_primary R@1 | 73.4% | 83.7% | **84.3%** |
+| wc_primary R@5 | 98.0% | 97.2% | **98.8%** |
+| wc_primary R@10 | 99.4% | 97.5% | **99.5%** |
+| cbow_raw R@1 | 67.2% | 77.9% | **77.9%** |
+| cbow_raw R@5 | 91.6% | 95.4% | **95.4%** |
+
+Test C (K=50 per-approach) is the recommended evaluation mode: it
+combines the honesty of per-approach search with Found close to 100%.
+The `--max-paths` / `-k` flag in `scoring_eval.py` makes it easy to
+tune the beam for production trade-offs.
+
+---
+
+## Edge Weight Design
+
+`score_graph()` (in `sanskrit_parser/parser/datastructures.py`) sets
+edge weights as:
+
+- `start → w`: score single word `[w]`
+- `w → end`: score single word `[w]`
+- `w1 → w2`: score bigram `str(w1) + " " + str(w2)` (two-word sentence)
+
+All scores are negated for search (lower weight = better path).
+This bigram weighting is critical — early experiments with unigram
+(destination-only) edge weights gave Found of only 91.3% for
+`cbow_raw`, compared to 97.8% with the correct bigram scheme.

--- a/metrics/scoring_eval.py
+++ b/metrics/scoring_eval.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""
+Evaluate sandhi split scoring approaches using Boundary-F1 and Recall@K.
+
+Each approach runs its own DAG search (weighted or unweighted) with max_paths=10.
+
+Compares:
+  A. Min-words: unweighted search (fewer words = better)
+  B. CBOW+SP raw: CBOW-weighted search
+  C. CBOW+SP normalized: CBOW/piece-weighted search
+  D. Word-vector: reranker on unweighted pool (per-edge weight not feasible)
+  E. Word-count primary + CBOW tiebreaker (unweighted search + rerank, default)
+
+Usage:
+  python metrics/scoring_eval.py --count 200               (limited, fast)
+  python metrics/scoring_eval.py                           (all 9042 entries)
+  python metrics/scoring_eval.py --max-paths 50            (wider beam)
+  python metrics/scoring_eval.py --max-paths 200 --count 500
+"""
+
+import heapq, logging, os, sys, inspect, time
+from collections import defaultdict
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+from tqdm import tqdm
+
+from indic_transliteration import sanscript
+from sanskrit_parser.base.sanskrit_base import SanskritObject, outputctx
+from sanskrit_parser.parser.sandhi_analyzer import LexicalSandhiAnalyzer
+from sanskrit_parser.util.lexical_scorer import Scorer, gensim_enabled
+
+BASE_DIR = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+DATA_DIR = os.path.join(BASE_DIR, '..', 'tests', 'SandhiKosh')
+KOSH_FILE = os.path.join(DATA_DIR, 'Result.xls')
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.WARNING)
+logging.getLogger('gensim').setLevel(logging.WARNING)
+
+# ---------------------------------------------------------------------------
+# Metric helpers
+# ---------------------------------------------------------------------------
+
+def split_boundaries(words):
+    """Return set of character offsets where word boundaries occur.
+
+    Given ['asti', 'uttarasyAm', 'diSi', 'devatAtmA'],
+    returns {4, 15, 19} (positions in the concatenated string).
+    """
+    pos = 0
+    boundaries = set()
+    for w in words:
+        pos += len(w)
+        boundaries.add(pos)
+    boundaries.discard(pos)  # remove end-of-string position
+    return boundaries
+
+
+def boundary_f1(candidate_words, reference_words):
+    """Compute Boundary-F1 between candidate and reference word splits."""
+    ref_bounds = split_boundaries(reference_words)
+    cand_bounds = split_boundaries(candidate_words)
+    true_pos = len(ref_bounds & cand_bounds)
+    pred_pos = len(cand_bounds)
+    actual_pos = len(ref_bounds)
+    if pred_pos == 0 and actual_pos == 0:
+        return 1.0
+    prec = true_pos / pred_pos if pred_pos > 0 else 0.0
+    rec = true_pos / actual_pos if actual_pos > 0 else 0.0
+    f1 = 2 * prec * rec / (prec + rec) if (prec + rec) > 0 else 0.0
+    return f1
+
+
+# ---------------------------------------------------------------------------
+# Weighted DAG search
+# ---------------------------------------------------------------------------
+
+def _shortest_paths_weighted(G, source, target, k, weight_map):
+    """Return up to k paths from source to target, sorted by total weight.
+
+    weight_map: dict of (u,v) -> float (smaller = better / cheaper)
+    Uses topological DP with per-node beam (k).
+    Returns list of (total_cost, [node, ...]) including start and end nodes.
+    """
+    final_paths = {node: [] for node in G.nodes()}
+    temp_heaps = {node: [] for node in G.nodes()}
+    final_paths[source] = [(0, None, None)]
+
+    for u in nx.topological_sort(G):
+        if u != source:
+            final_paths[u] = sorted([(-c, p, idx) for c, p, idx in temp_heaps[u]])
+        if not final_paths[u]:
+            continue
+        for v in G.successors(u):
+            ew = weight_map.get((u, v), 1)
+            for i, (cost, _, _) in enumerate(final_paths[u]):
+                new_cost = cost + ew
+                if len(temp_heaps[v]) < k:
+                    heapq.heappush(temp_heaps[v], (-new_cost, u, i))
+                elif new_cost < -temp_heaps[v][0][0]:
+                    heapq.heapreplace(temp_heaps[v], (-new_cost, u, i))
+
+    results = []
+    for cost, parent, idx in final_paths[target]:
+        path = [target]
+        curr_p, curr_idx = parent, idx
+        while curr_p is not None:
+            path.append(curr_p)
+            _, curr_p, curr_idx = final_paths[curr_p][curr_idx]
+        results.append((cost, path[::-1]))
+    return results
+
+
+def _edge_weights_cbow_raw(G, start, end, scorer):
+    """Edge weights matching original score_graph().
+
+    start→w:  score single word [w]
+    w→end:    score single word [w]
+    w1→w2:    score bigram "w1 w2" (matching score_graph's tuple-as-two-words)
+    Weight = -score (negative so search minimizes).
+    """
+    weights = {}
+    for u, v in G.edges():
+        if u == start:
+            s = str(v)
+        elif v == end:
+            s = str(u)
+        else:
+            s = str(u) + " " + str(v)
+        pieces = scorer.sp.EncodeAsPieces(s)
+        raw = scorer.model.score([pieces])[0]
+        weights[(u, v)] = -raw
+    return weights
+
+
+def _edge_weights_cbow_norm(G, start, end, scorer):
+    """Edge weights = -(CBOW log-prob per piece), matching bigram scheme."""
+    weights = {}
+    for u, v in G.edges():
+        if u == start:
+            s = str(v)
+        elif v == end:
+            s = str(u)
+        else:
+            s = str(u) + " " + str(v)
+        pieces = scorer.sp.EncodeAsPieces(s)
+        raw = scorer.model.score([pieces])[0]
+        weights[(u, v)] = -raw / max(len(pieces), 1)
+    return weights
+
+
+# ---------------------------------------------------------------------------
+# Scoring functions
+# ---------------------------------------------------------------------------
+
+def score_min_words(path):
+    """Negative word count: fewer words = higher score."""
+    return -len(path)
+
+
+def score_cbow_raw(paths, scorer):
+    """Raw CBOW sum-of-log-probs (current score_strings)."""
+    sentences = [" ".join(map(str, p)) for p in paths]
+    pieces = [scorer.sp.EncodeAsPieces(s) for s in sentences]
+    raw = scorer.model.score(pieces, total_sentences=len(sentences))
+    return list(raw)
+
+
+def score_cbow_normalized(paths, scorer):
+    """CBOW score normalized by piece count (avg log-prob per piece)."""
+    sentences = [" ".join(map(str, p)) for p in paths]
+    pieces = [scorer.sp.EncodeAsPieces(s) for s in sentences]
+    raw = scorer.model.score(pieces, total_sentences=len(sentences))
+    return [s / max(len(p), 1) for s, p in zip(raw, pieces)]
+
+
+def score_wordvec(paths, scorer):
+    """Average cosine similarity between adjacent word vectors.
+
+    Each word vector = average of its SentencePiece piece vectors.
+    """
+    scores = []
+    for path in paths:
+        vecs = []
+        for w in path:
+            word_str = str(w)
+            pieces = scorer.sp.EncodeAsPieces(word_str)
+            piece_vecs = [scorer.model.wv[p] for p in pieces if p in scorer.model.wv]
+            if not piece_vecs:
+                vecs = None
+                break
+            vecs.append(np.mean(piece_vecs, axis=0))
+        if vecs is None or len(vecs) < 2:
+            scores.append(-1.0)
+            continue
+        sims = []
+        for i in range(len(vecs) - 1):
+            v1, v2 = vecs[i], vecs[i + 1]
+            n1, n2 = np.linalg.norm(v1), np.linalg.norm(v2)
+            if n1 == 0 or n2 == 0:
+                sims.append(0.0)
+            else:
+                sims.append(np.dot(v1, v2) / (n1 * n2))
+        scores.append(np.mean(sims) if sims else -1.0)
+    return scores
+
+
+def score_wordcount_primary(paths, cbow_scores):
+    """Word count primary, CBOW tiebreaker (current default)."""
+    return list(zip([-len(p) for p in paths], cbow_scores))
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+def evaluate_single(graph, ref_words, scorer, max_paths=10):
+    """Run each approach with its own search and evaluate top-K.
+
+    Returns dict of {approach_name: {pos, f1_at_1, f1_at_10, recall_at_k}}
+    """
+    ref_str = list(ref_words)
+    results = {}
+
+    graph.lock_start()
+    G = graph.G
+    start = graph.start
+    end = graph.end
+
+    if start not in G or end not in G:
+        return None
+
+    # Unit weight map for unweighted search
+    unit = {(u, v): 1 for u, v in G.edges()}
+
+    # === Unweighted search (shared base for min_words, wc_primary, wordvec) ===
+    splits_full = _shortest_paths_weighted(G, start, end, max_paths, unit)
+    if not splits_full:
+        return None
+    path_set = [[str(w) for w in p[1:-1]] for _, p in splits_full]
+    # Keep inner node objects for CBOW scoring
+    splits_inner = [p[1:-1] for _, p in splits_full]
+
+    # === min_words: unweighted search, no reranking ===
+    results['min_words'] = _compute_metrics(list(range(len(path_set))),
+                                            path_set, ref_str)
+
+    if not gensim_enabled:
+        return results
+
+    # === wc_primary: unweighted search + CBOW tiebreaker ===
+    cbow_raw_scores = score_cbow_raw(splits_inner, scorer)
+    combined = score_wordcount_primary(path_set, cbow_raw_scores)
+    scored = sorted(enumerate(combined), key=lambda x: (-x[1][0], -x[1][1]))
+    order = [i for i, _ in scored]
+    results['wc_primary'] = _compute_metrics(order, path_set, ref_str)
+
+    # === cbow_raw: CBOW-weighted search ===
+    cbow_w = _edge_weights_cbow_raw(G, start, end, scorer)
+    splits_cb = _shortest_paths_weighted(G, start, end, max_paths, cbow_w)
+    path_set_cb = ([[str(w) for w in p[1:-1]] for _, p in splits_cb]
+                   if splits_cb else [])
+    results['cbow_raw'] = _compute_metrics(list(range(len(path_set_cb))),
+                                           path_set_cb, ref_str)
+
+    # === cbow_norm: CBOW-normalized-weighted search ===
+    cbow_nw = _edge_weights_cbow_norm(G, start, end, scorer)
+    splits_cn = _shortest_paths_weighted(G, start, end, max_paths, cbow_nw)
+    path_set_cn = ([[str(w) for w in p[1:-1]] for _, p in splits_cn]
+                   if splits_cn else [])
+    results['cbow_norm'] = _compute_metrics(list(range(len(path_set_cn))),
+                                            path_set_cn, ref_str)
+
+    # === wordvec: re-ranker on the unweighted pool only ===
+    # (not edge-weight compatible; needs cross-word cosine sim)
+    wv_scores = score_wordvec(splits_inner, scorer)
+    scored = sorted(enumerate(wv_scores), key=lambda x: -x[1])
+    order = [i for i, _ in scored]
+    results['wordvec'] = _compute_metrics(order, path_set, ref_str)
+
+    return results
+
+
+def _compute_metrics(order, path_strs, ref_str):
+    """Compute position, recall@K, and top-K F1."""
+    n = len(order)
+    try:
+        pos = order.index(next(i for i, p in enumerate(path_strs) if p == ref_str))
+    except (StopIteration, ValueError):
+        pos = None
+
+    out = {'n_paths': n, 'pos': pos}
+
+    for k in [1, 5, 10]:
+        out[f'recall@{k}'] = 1 if pos is not None and pos < k else 0
+
+    # Top-1 F1
+    if n > 0:
+        best = path_strs[order[0]]
+        out['f1_at_1'] = boundary_f1(best, ref_str)
+    else:
+        out['f1_at_1'] = 0.0
+
+    # Top-10 F1 (best among first 10)
+    best_f1 = 0.0
+    for rank in range(min(10, n)):
+        cand = path_strs[order[rank]]
+        f1 = boundary_f1(cand, ref_str)
+        best_f1 = max(best_f1, f1)
+    out['f1_at_10'] = best_f1
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def load_kosh(count=None):
+    """Load sandhi kosha entries."""
+    kosh = pd.read_excel(KOSH_FILE)
+    passing = kosh[kosh['Status'] == 'Pass']
+    if count:
+        passing = passing.head(count)
+    entries = []
+    for _, row in passing.iterrows():
+        word = row['Word']
+        split_str = row['Split'].strip().replace(' ', '+')
+        ref_split = [SanskritObject(x, encoding=sanscript.DEVANAGARI,
+                                    strict_io=True,
+                                    replace_ending_visarga=None).canonical()
+                     for x in split_str.split('+')]
+        entries.append({
+            'word': word,
+            'word_slp': SanskritObject(word, encoding=sanscript.DEVANAGARI,
+                                       strict_io=True,
+                                       replace_ending_visarga=None).canonical(),
+            'ref': ref_split,
+        })
+    return entries
+
+
+def main(count=None, max_paths=10):
+    entries = load_kosh(count)
+    logger.info("Loaded %d kosh entries, max_paths=%d", len(entries), max_paths)
+
+    anal = LexicalSandhiAnalyzer()
+    scorer = Scorer() if gensim_enabled else None
+
+    # Accumulate per-approach stats
+    stats = defaultdict(lambda: {
+        'count': 0, 'found': 0, 'recall_1': 0, 'recall_5': 0,
+        'recall_10': 0, 'sum_pos': 0,
+        'sum_f1_1': 0.0, 'sum_f1_10': 0.0,
+    })
+
+    skipped = 0
+    start = time.time()
+
+    with outputctx(False):
+        for i, ent in enumerate(tqdm(entries)):
+            s = SanskritObject(ent['word'], encoding=sanscript.DEVANAGARI,
+                               strict_io=True, replace_ending_visarga=None)
+            graph = anal.getSandhiSplits(s)
+            if graph is None:
+                skipped += 1
+                continue
+
+            result = evaluate_single(graph, ent['ref'], scorer, max_paths=max_paths)
+            if result is None:
+                skipped += 1
+                continue
+
+            for approach, metrics in result.items():
+                s = stats[approach]
+                s['count'] += 1
+                if metrics['pos'] is not None:
+                    s['found'] += 1
+                    s['recall_1'] += metrics['recall@1']
+                    s['recall_5'] += metrics['recall@5']
+                    s['recall_10'] += metrics['recall@10']
+                    s['sum_pos'] += metrics['pos']
+                s['sum_f1_1'] += metrics['f1_at_1']
+                s['sum_f1_10'] += metrics['f1_at_10']
+
+            if (i + 1) % 200 == 0:
+                elapsed = time.time() - start
+                logger.info("Processed %d/%d (%.1f/s)", i + 1, len(entries),
+                            (i + 1) / elapsed)
+
+    elapsed = time.time() - start
+    logger.info("Done. Took %.1fs (%d entries, %d skipped)", elapsed,
+                len(entries), skipped)
+
+    # Print report
+    print()
+    print("=" * 78)
+    print(f"{'Approach':<20} {'Recall@1':>9} {'Recall@5':>9} {'Recall@10':>9} "
+          f"{'F1@1':>7} {'F1@10':>7} {'AvgPos':>7} {'Found':>6}")
+    print("-" * 78)
+    for approach in ['min_words', 'cbow_raw', 'cbow_norm', 'wordvec', 'wc_primary']:
+        if approach not in stats:
+            continue
+        s = stats[approach]
+        c = s['count']
+        r1 = s['recall_1'] / c * 100 if c else 0
+        r5 = s['recall_5'] / c * 100 if c else 0
+        r10 = s['recall_10'] / c * 100 if c else 0
+        f1_1 = s['sum_f1_1'] / c * 100 if c else 0
+        f1_10 = s['sum_f1_10'] / c * 100 if c else 0
+        avg_pos = s['sum_pos'] / s['found'] if s['found'] else 0
+        found_pct = s['found'] / c * 100 if c else 0
+        print(f"{approach:<20} {r1:>8.1f}% {r5:>8.1f}% {r10:>8.1f}% "
+              f"{f1_1:>6.1f}% {f1_10:>6.1f}% "
+              f"{avg_pos:>6.1f}  {found_pct:>5.1f}%")
+    print("=" * 78)
+
+    # Also report not-found-in-graph
+    print(f"\nSkipped (no graph): {skipped} / {len(entries)}")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO,
+                        format="%(levelname)s:%(name)s:%(message)s")
+    import argparse
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--count', type=int, default=None,
+                   help='Limit to N entries')
+    p.add_argument('--max-paths', '-k', type=int, default=10,
+                   help='Beam width / number of paths per approach (default: 10)')
+    args = p.parse_args()
+    main(args.count, args.max_paths)

--- a/metrics/scoring_eval_shared_pool.py
+++ b/metrics/scoring_eval_shared_pool.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""
+Evaluate sandhi split scoring approaches using Boundary-F1 and Recall@K.
+
+Finds 200 unweighted paths from the graph (K=200 beam), then re-ranks
+the same pool using each scoring approach.  This measures how well
+each scoring function ranks a large set of candidates, but does NOT
+measure how each approach would perform if it drove its own search.
+
+Compares:
+  A. Min-words: sort by word count (fewer = better)
+  B. CBOW+SP raw: current model.score() (sum of log-probs)
+  C. CBOW+SP normalized: model.score() / piece_count
+  D. Word-vector: avg piece vecs -> cosine sim between adjacent word vecs
+  E. Word-count primary + CBOW tiebreaker (current default)
+
+Usage:
+  python metrics/scoring_eval_shared_pool.py --count 200
+  python metrics/scoring_eval_shared_pool.py
+"""
+
+import logging, os, sys, inspect, time
+from collections import defaultdict
+
+import numpy as np
+import pandas as pd
+
+from indic_transliteration import sanscript
+from sanskrit_parser.base.sanskrit_base import SanskritObject, outputctx
+from sanskrit_parser.parser.sandhi_analyzer import LexicalSandhiAnalyzer
+from sanskrit_parser.util.lexical_scorer import Scorer, gensim_enabled
+
+BASE_DIR = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+DATA_DIR = os.path.join(BASE_DIR, '..', 'tests', 'SandhiKosh')
+KOSH_FILE = os.path.join(DATA_DIR, 'Result.xls')
+
+logger = logging.getLogger(__name__)
+
+
+def split_boundaries(words):
+    pos = 0
+    boundaries = set()
+    for w in words:
+        pos += len(w)
+        boundaries.add(pos)
+    boundaries.discard(pos)
+    return boundaries
+
+
+def boundary_f1(candidate_words, reference_words):
+    ref_bounds = split_boundaries(reference_words)
+    cand_bounds = split_boundaries(candidate_words)
+    true_pos = len(ref_bounds & cand_bounds)
+    pred_pos = len(cand_bounds)
+    actual_pos = len(ref_bounds)
+    if pred_pos == 0 and actual_pos == 0:
+        return 1.0
+    prec = true_pos / pred_pos if pred_pos > 0 else 0.0
+    rec = true_pos / actual_pos if actual_pos > 0 else 0.0
+    f1 = 2 * prec * rec / (prec + rec) if (prec + rec) > 0 else 0.0
+    return f1
+
+
+def score_min_words(path):
+    return -len(path)
+
+
+def score_cbow_raw(paths, scorer):
+    sentences = [" ".join(map(str, p)) for p in paths]
+    pieces = [scorer.sp.EncodeAsPieces(s) for s in sentences]
+    raw = scorer.model.score(pieces, total_sentences=len(sentences))
+    return list(raw)
+
+
+def score_cbow_normalized(paths, scorer):
+    sentences = [" ".join(map(str, p)) for p in paths]
+    pieces = [scorer.sp.EncodeAsPieces(s) for s in sentences]
+    raw = scorer.model.score(pieces, total_sentences=len(sentences))
+    return [s / max(len(p), 1) for s, p in zip(raw, pieces)]
+
+
+def score_wordvec(paths, scorer):
+    scores = []
+    for path in paths:
+        vecs = []
+        for w in path:
+            word_str = str(w)
+            pieces = scorer.sp.EncodeAsPieces(word_str)
+            piece_vecs = [scorer.model.wv[p] for p in pieces if p in scorer.model.wv]
+            if not piece_vecs:
+                vecs = None
+                break
+            vecs.append(np.mean(piece_vecs, axis=0))
+        if vecs is None or len(vecs) < 2:
+            scores.append(-1.0)
+            continue
+        sims = []
+        for i in range(len(vecs) - 1):
+            v1, v2 = vecs[i], vecs[i + 1]
+            n1, n2 = np.linalg.norm(v1), np.linalg.norm(v2)
+            if n1 == 0 or n2 == 0:
+                sims.append(0.0)
+            else:
+                sims.append(np.dot(v1, v2) / (n1 * n2))
+        scores.append(np.mean(sims) if sims else -1.0)
+    return scores
+
+
+def score_wordcount_primary(paths, cbow_scores):
+    return list(zip([-len(p) for p in paths], cbow_scores))
+
+
+def evaluate_single(graph, ref_words, scorer, max_k=200):
+    """Find up to max_k unweighted paths, then re-rank by each approach."""
+    splits = graph.find_all_paths(max_paths=max_k, score=False)
+    if not splits:
+        return None
+
+    results = {}
+    path_strs = [[str(w) for w in p] for p in splits]
+    ref_str = list(ref_words)
+
+    # -- Approach A: Min-words --
+    scored = [(score_min_words(p), i) for i, p in enumerate(path_strs)]
+    scored.sort(key=lambda x: -x[0])
+    order = [i for _, i in scored]
+    results['min_words'] = _compute_metrics(order, path_strs, ref_str)
+
+    if not gensim_enabled:
+        return results
+
+    # -- CBOW scores (shared) --
+    cbow_raw = score_cbow_raw(splits, scorer)
+    cbow_norm = score_cbow_normalized(splits, scorer)
+
+    # -- Approach B: CBOW raw --
+    scored = sorted(enumerate(cbow_raw), key=lambda x: -x[1])
+    order = [i for i, _ in scored]
+    results['cbow_raw'] = _compute_metrics(order, path_strs, ref_str)
+
+    # -- Approach C: CBOW normalized --
+    scored = sorted(enumerate(cbow_norm), key=lambda x: -x[1])
+    order = [i for i, _ in scored]
+    results['cbow_norm'] = _compute_metrics(order, path_strs, ref_str)
+
+    # -- Approach D: Word-vector --
+    wv_scores = score_wordvec(splits, scorer)
+    scored = sorted(enumerate(wv_scores), key=lambda x: -x[1])
+    order = [i for i, _ in scored]
+    results['wordvec'] = _compute_metrics(order, path_strs, ref_str)
+
+    # -- Approach E: Word count primary, CBOW tiebreaker --
+    combined = score_wordcount_primary(path_strs, cbow_raw)
+    scored = sorted(enumerate(combined), key=lambda x: (-x[1][0], -x[1][1]))
+    order = [i for i, _ in scored]
+    results['wc_primary'] = _compute_metrics(order, path_strs, ref_str)
+
+    return results
+
+
+def _compute_metrics(order, path_strs, ref_str):
+    n = len(order)
+    try:
+        pos = order.index(next(i for i, p in enumerate(path_strs) if p == ref_str))
+    except (StopIteration, ValueError):
+        pos = None
+
+    out = {'n_paths': n, 'pos': pos}
+    for k in [1, 5, 10, 50]:
+        out[f'recall@{k}'] = 1 if pos is not None and pos < k else 0
+
+    if n > 0:
+        best = path_strs[order[0]]
+        out['f1_at_1'] = boundary_f1(best, ref_str)
+    else:
+        out['f1_at_1'] = 0.0
+
+    best_f1 = 0.0
+    for rank in range(min(10, n)):
+        cand = path_strs[order[rank]]
+        f1 = boundary_f1(cand, ref_str)
+        best_f1 = max(best_f1, f1)
+    out['f1_at_10'] = best_f1
+
+    return out
+
+
+def load_kosh(count=None):
+    kosh = pd.read_excel(KOSH_FILE)
+    passing = kosh[kosh['Status'] == 'Pass']
+    if count:
+        passing = passing.head(count)
+    entries = []
+    for _, row in passing.iterrows():
+        word = row['Word']
+        split_str = row['Split'].strip().replace(' ', '+')
+        ref_split = [SanskritObject(x, encoding=sanscript.DEVANAGARI,
+                                    strict_io=True,
+                                    replace_ending_visarga=None).canonical()
+                     for x in split_str.split('+')]
+        entries.append({
+            'word': word,
+            'word_slp': SanskritObject(word, encoding=sanscript.DEVANAGARI,
+                                       strict_io=True,
+                                       replace_ending_visarga=None).canonical(),
+            'ref': ref_split,
+        })
+    return entries
+
+
+def main(count=None):
+    entries = load_kosh(count)
+    logger.info("Loaded %d kosh entries", len(entries))
+
+    anal = LexicalSandhiAnalyzer()
+    scorer = Scorer() if gensim_enabled else None
+
+    stats = defaultdict(lambda: {
+        'count': 0, 'found': 0, 'recall_1': 0, 'recall_5': 0,
+        'recall_10': 0, 'recall_50': 0, 'sum_pos': 0,
+        'sum_f1_1': 0.0, 'sum_f1_10': 0.0,
+    })
+
+    skipped = 0
+    start = time.time()
+
+    with outputctx(False):
+        for i, ent in enumerate(entries):
+            s = SanskritObject(ent['word'], encoding=sanscript.DEVANAGARI,
+                               strict_io=True, replace_ending_visarga=None)
+            graph = anal.getSandhiSplits(s)
+            if graph is None:
+                skipped += 1
+                continue
+
+            result = evaluate_single(graph, ent['ref'], scorer)
+            if result is None:
+                skipped += 1
+                continue
+
+            for approach, metrics in result.items():
+                s = stats[approach]
+                s['count'] += 1
+                if metrics['pos'] is not None:
+                    s['found'] += 1
+                    s['recall_1'] += metrics['recall@1']
+                    s['recall_5'] += metrics['recall@5']
+                    s['recall_10'] += metrics['recall@10']
+                    s['recall_50'] += metrics['recall@50']
+                    s['sum_pos'] += metrics['pos']
+                s['sum_f1_1'] += metrics['f1_at_1']
+                s['sum_f1_10'] += metrics['f1_at_10']
+
+            if (i + 1) % 200 == 0:
+                elapsed = time.time() - start
+                logger.info("Processed %d/%d (%.1f/s)", i + 1, len(entries),
+                            (i + 1) / elapsed)
+
+    elapsed = time.time() - start
+    logger.info("Done. Took %.1fs (%d entries, %d skipped)", elapsed,
+                len(entries), skipped)
+
+    print()
+    print("=" * 90)
+    print(f"{'Approach':<20} {'Recall@1':>9} {'Recall@5':>9} {'Recall@10':>9} "
+          f"{'Recall@50':>9} {'F1@1':>7} {'F1@10':>7} {'AvgPos':>7} {'Found':>6}")
+    print("-" * 90)
+    for approach in ['min_words', 'cbow_raw', 'cbow_norm', 'wordvec', 'wc_primary']:
+        if approach not in stats:
+            continue
+        s = stats[approach]
+        c = s['count']
+        r1 = s['recall_1'] / c * 100 if c else 0
+        r5 = s['recall_5'] / c * 100 if c else 0
+        r10 = s['recall_10'] / c * 100 if c else 0
+        r50 = s['recall_50'] / c * 100 if c else 0
+        f1_1 = s['sum_f1_1'] / c * 100 if c else 0
+        f1_10 = s['sum_f1_10'] / c * 100 if c else 0
+        avg_pos = s['sum_pos'] / s['found'] if s['found'] else 0
+        found_pct = s['found'] / c * 100 if c else 0
+        print(f"{approach:<20} {r1:>8.1f}% {r5:>8.1f}% {r10:>8.1f}% "
+              f"{r50:>8.1f}% {f1_1:>6.1f}% {f1_10:>6.1f}% "
+              f"{avg_pos:>6.1f}  {found_pct:>5.1f}%")
+    print("=" * 90)
+    print(f"\nSkipped (no graph): {skipped} / {len(entries)}")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO,
+                        format="%(levelname)s:%(name)s:%(message)s")
+    import argparse
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--count', type=int, default=None,
+                   help='Limit to N entries')
+    args = p.parse_args()
+    main(args.count)

--- a/sanskrit_parser/__init__.py
+++ b/sanskrit_parser/__init__.py
@@ -37,6 +37,8 @@ def enable_console_logger(level=logging.INFO,
     console.setFormatter(formatter)
     # add the handler to the root logger
     logger.addHandler(console)
+    if logger.level == logging.NOTSET or level < logger.level:
+        logger.setLevel(level)
 
 
 def enable_file_logger(log_file_name='SanskritParser.log',
@@ -56,6 +58,9 @@ def enable_file_logger(log_file_name='SanskritParser.log',
     fh.setLevel(level)
     fh.setFormatter(formatter)
     logger.addHandler(fh)
+    if logger.level == logging.NOTSET or level < logger.level:
+        logger.setLevel(level)
+
 
 
 __version__ = '0.2.6'

--- a/sanskrit_parser/parser/datastructures.py
+++ b/sanskrit_parser/parser/datastructures.py
@@ -177,16 +177,19 @@ class SandhiGraph(object):
         """
         if self.roots:
             self.lock_start()
-        if score:
-            self.score_graph()
-        paths = [x[1][1:-1] for x in k_shortest_paths_dag_optimized(self.G, self.start, self.end, max_paths)]
+        PATH_OVERSAMPLING_FACTOR = 5
+        # Find PATH_OVERSAMPLING_FACTOR x more paths than requested, using just the length of the path as the metric to find shorter paths
+        paths = [x[1][1:-1] for x in k_shortest_paths_dag_optimized(self.G, self.start, self.end, max_paths*PATH_OVERSAMPLING_FACTOR)]
         if score:
             scores = self.scorer.score_splits(paths)
-            path_scores = zip(paths, scores)
-            sorted_path_scores = sorted(path_scores, key=operator.itemgetter(1), reverse=True)
-            logger.debug("Sorted paths with scores:\n %s", sorted_path_scores)
-            paths, _ = zip(*sorted_path_scores)
-        return paths
+            # Primary key: word count (fewer words = better, anti-fragmentation
+            # prior).  Secondary key: CBOW score for equal-length paths.
+            # See scoring evaluation in metrics folder
+            path_scores = list(zip(paths, scores))
+            path_scores.sort(key=lambda ps: (len(ps[0]), -ps[1]))
+            logger.debug("Sorted paths with scores:\n %s", path_scores)
+            paths, _ = zip(*path_scores)
+        return islice(paths, max_paths)
 
     def __str__(self):
         """ Print representation of DAG """


### PR DESCRIPTION
After switching to the DAG optimized topological sort based path finding algorithm, path finding on the Sandhi splits graph is very cheap  - takes ~4.5% of total time based on profiling the test suite, even though the test suite uses max_paths = 300, compared to default of 10. I created a comparison of a few [scoring options](https://github.com/avinashvarna/sanskrit_parser/blob/scoring_improvements/metrics/Scoring_evaluation.md) and found that finding 50 paths by number of words, and then reranking them using the scorer provides the best trade-off (`wc_primary` in [Test C](https://github.com/avinashvarna/sanskrit_parser/blob/scoring_improvements/metrics/Scoring_evaluation.md#test-c-per-approach-dag-search-k50)). I've made that change to the scoring/path-finding algorithm.